### PR TITLE
Enable sorting for non-interactive mode

### DIFF
--- a/iterfzf/__init__.py
+++ b/iterfzf/__init__.py
@@ -36,7 +36,7 @@ def iterfzf(
     filter_query=None, query='', encoding=None,
     executable=BUNDLED_EXECUTABLE or EXECUTABLE_NAME
 ):
-    cmd = [executable, '--no-sort', '--prompt=' + prompt]
+    cmd = [executable, '--prompt=' + prompt]
     if not extended:
         cmd.append('--no-extended')
     if case_sensitive is not None:


### PR DESCRIPTION
This will start prefering the best match in non-interactive mode, rather
than what seems to be the option sorted last alphabetically that is
still a fuzzy match.

This keeps the options sorted alphabetically in interactive mode (which
means options will not re-order as you type), but we can consider if we
actually want them live-sorted with the best match on the bottom then as
well.